### PR TITLE
Fix holdings service not accessible from host

### DIFF
--- a/chapter-6/docker-compose.yml
+++ b/chapter-6/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     links:
       - market-data
     ports:
-      - 80:8000
+      - 80:8001


### PR DESCRIPTION
The holdings service was running on port 8001, but in `docker-compose.yml` the port was bonded to 8000